### PR TITLE
Remove system-dependent integer dependency

### DIFF
--- a/caentools/read.py
+++ b/caentools/read.py
@@ -29,10 +29,8 @@ def read_scipp(filename, clock=None, sort=True, channel=None):
 
     dat = read_dat(filename)
     # concatenate the two 32-bit time-words, divide by the clock frequency to get seconds
-    th = dat['time_high'].astype('int') << 32
-    tl = dat['time_low'].astype('int')
-    time = (th + tl) / clock  
-    time = array(values=time, dims=['event'], unit='sec')
+    time = array(values=(dat['time_high'] * 2**32 + dat['time_low']) / clock,
+                 dims=['event'], unit='sec')
     chan = array(values=dat['tube_channel'].astype('int'), dims=['event'])
     ampl_a = array(values=1.0 * dat['amplitude_a'].astype('int'), dims=['event'], unit='mV')
     ampl_b = array(values=1.0 * dat['amplitude_b'].astype('int'), dims=['event'], unit='mV')


### PR DESCRIPTION
By replacing the bit-shift by multiplication and letting standard type promotion handle the conversion from unsigned integers to floating-point (time) values, there is no longer any difference between 32-bit and 64-bit Numpy 'int' values.

Some care should probably be taken still to ensure numbers read from data files are interpreted correctly.